### PR TITLE
Order posts by publication date

### DIFF
--- a/app/assets/stylesheets/proclaim/posts.css.scss
+++ b/app/assets/stylesheets/proclaim/posts.css.scss
@@ -26,6 +26,34 @@ div.post_excerpt_information
 	margin-top: 10px;
 }
 
+td#draft_posts
+{
+	width: 40%;
+	vertical-align: top;
+
+	h2
+	{
+		margin-top: 0;
+	}
+
+	h3
+	{
+		margin-bottom: 0;
+	}
+
+	div#draft_list
+	{
+		border: solid rgba(0, 0, 0, 0.3) 1px;
+		padding: 10px;
+		margin-left: 20px;
+	}
+
+	div.post_excerpt_information
+	{
+		margin-top: 0;
+	}
+}
+
 input.datetime_picker
 {
 	cursor: pointer;

--- a/app/controllers/proclaim/posts_controller.rb
+++ b/app/controllers/proclaim/posts_controller.rb
@@ -9,7 +9,7 @@ module Proclaim
 
 		# GET /posts
 		def index
-			@posts = policy_scope(Post)
+			@posts = policy_scope(Post).order(published_at: :desc, updated_at: :desc)
 			authorize Post
 		end
 

--- a/app/views/proclaim/posts/index.html.erb
+++ b/app/views/proclaim/posts/index.html.erb
@@ -5,26 +5,59 @@
 <% if @posts.empty? %>
 	<p>No posts have been made, yet.</p>
 <% else %>
-	<% @posts.each do |post| %>
-		<h1><%= link_to post.title, post %></h1>
-		<div id = "post_<%= post.id %>">
-			<% excerpt = post.excerpt %>
-			<span class = "excerpt"><%= excerpt %></span>
+	<table style = "width: 100%;">
+		<tr>
+			<td id = "published_posts">
+				<% @posts.published.each do |post| %>
+				<h1><%= link_to post.title, post %></h1>
+				<div id = "post_<%= post.id %>">
+					<% excerpt = post.excerpt %>
+					<span class = "excerpt"><%= excerpt %></span>
 
-			<% if excerpt.length < post.body.length %>
-				. . . <%= link_to "(more)", post %>
+					<% if excerpt.length < post.body.length %>
+						. . . <%= link_to "(more)", post %>
+					<% end %>
+				</div>
+				<div class = "post_excerpt_information">
+					<div style = "float: right;">
+						<% if policy(post).edit? %>
+							<%= link_to 'Edit', edit_post_path(post) %>
+						<% end %>
+						<% if policy(post).destroy? %>
+							<%= link_to 'Delete', post, method: :delete, data: { confirm: 'Are you sure?' } %>
+						<% end %>
+					</div>
+					<%= post.author.send(Proclaim.author_name_method) %><br />
+					<%= timeago_tag post.updated_at, format: "%B %d, %Y" %>
+				</div>
 			<% end %>
-		</div>
-		<div class = "post_excerpt_information">
-			<div style = "float: right;">
-				<% if policy(post).edit? %>
-					<%= link_to 'Edit', edit_post_path(post) %>
-				<% end %>
-				<% if policy(post).destroy? %>
-					<%= link_to 'Delete', post, method: :delete, data: { confirm: 'Are you sure?' } %>
-				<% end %>
-			</div>
-			<%= post.author.send(Proclaim.author_name_method) %>
-		</div>
-	<% end %>
+			</td>
+
+			<% drafts = @posts.draft %>
+			<% unless drafts.blank? %>
+				<td id = "draft_posts">
+					<div id = "draft_list">
+						<h2>Drafts</h2>
+						<% drafts.each do |post| %>
+							<h3 class = "draft_list_item">
+								<%= link_to post.title, post %>
+							</h3>
+							<div class = "post_excerpt_information">
+								<div style = "float: right;">
+									<% if policy(post).edit? %>
+										<%= link_to 'Edit', edit_post_path(post) %>
+									<% end %>
+									<% if policy(post).destroy? %>
+										<%= link_to 'Delete', post, method: :delete, data: { confirm: 'Are you sure?' } %>
+									<% end %>
+								</div>
+								<%= post.author.send(Proclaim.author_name_method) %><br />
+								<%= timeago_tag post.updated_at, format: "%B %d, %Y" %>
+							</div>
+						<% end %>
+					</div>
+				</td>
+			<% end %>
+		</tr>
+	</table>
 <% end %>

--- a/test/controllers/proclaim/posts_controller_test.rb
+++ b/test/controllers/proclaim/posts_controller_test.rb
@@ -40,6 +40,39 @@ module Proclaim
 			assert_includes assigns(:posts), post2
 		end
 
+		test "posts should be ordered by publication date" do
+			post1 = FactoryGirl.create(:published_post)
+			post2 = FactoryGirl.create(:published_post)
+
+			get :index
+			assert_response :success
+			assert_not_nil assigns(:posts)
+			assert_equal 2, assigns(:posts).count
+			assert_equal post2, assigns(:posts).first
+			assert_equal post1, assigns(:posts).last
+		end
+
+		test "drafts should be ordered by updated date" do
+			user = FactoryGirl.create(:user)
+			sign_in user
+
+			post1 = FactoryGirl.create(:post)
+			post2 = FactoryGirl.create(:post)
+			post3 = FactoryGirl.create(:post)
+
+			# Update post1 so its updated_at is newest
+			post2.body = "Updated Body"
+			post2.save
+
+			get :index
+			assert_response :success
+			assert_not_nil assigns(:posts)
+			assert_equal 3, assigns(:posts).count
+			assert_equal post2, assigns(:posts).first
+			assert_equal post3, assigns(:posts).second
+			assert_equal post1, assigns(:posts).last
+		end
+
 		test "should get new if logged in" do
 			user = FactoryGirl.create(:user)
 			sign_in user

--- a/test/integration/without_javascript/post_test.rb
+++ b/test/integration/without_javascript/post_test.rb
@@ -115,6 +115,36 @@ class PostTest < ActionDispatch::IntegrationTest
 		       "Post 2 should not contain a link to see more"
 	end
 
+	test "index should show posts ordered by publication date" do
+		post1 = FactoryGirl.create(:published_post)
+		post2 = FactoryGirl.create(:published_post)
+
+		visit proclaim.posts_path
+
+		assert page.body.index(post2.title) < page.body.index(post1.title),
+		       "Post 2 should be shown before post 1!"
+	end
+
+	test "index should show drafts ordered by modification date" do
+		user = FactoryGirl.create(:user)
+		sign_in user
+
+		post1 = FactoryGirl.create(:post)
+		post2 = FactoryGirl.create(:post)
+		post3 = FactoryGirl.create(:post)
+
+		# Update post1 so its updated_at is newest
+		post2.body = "Updated Body"
+		post2.save
+
+		visit proclaim.posts_path
+
+		assert page.body.index(post2.title) < page.body.index(post3.title),
+		       "Post 2 draft should be shown before post 3 draft!"
+		assert page.body.index(post3.title) < page.body.index(post1.title),
+		       "Post 3 draft should be shown before post 1 draft!"
+	end
+
 	test "show should show author name" do
 		post = FactoryGirl.create(:published_post)
 


### PR DESCRIPTION
This PR resolves #10 by ordering posts by publication date on the posts index. It also separates drafts from the main posts list (assuming a user is logged in).