### PR TITLE
Fix HTML entities from showing up in post titles

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,3 +1,4 @@
+  - Fixed post titles showing HTML entities
   - Fixed posts index to show published time instead of updated time
 
 v 0.2.1

--- a/app/views/proclaim/posts/_form.html.erb
+++ b/app/views/proclaim/posts/_form.html.erb
@@ -33,7 +33,7 @@
 	<% end %>
 
 	<div class = "post">
-		<h1 class = "post_title editable" data-disable-return="true" data-disable-toolbar="true" data-placeholder="Post Title"><%= @post.title %></h1>
+		<h1 class = "post_title editable" data-disable-return="true" data-disable-toolbar="true" data-placeholder="Post Title"><%= raw @post.title %></h1>
 
 		<div class = "post_body editable" data-placeholder = "Post Body" data-image-upload-path="<%= cache_image_path %>" data-image-delete-path="<%= discard_image_path %>">
 			<%= raw @post.body %>

--- a/app/views/proclaim/posts/show.html.erb
+++ b/app/views/proclaim/posts/show.html.erb
@@ -28,7 +28,7 @@
 </div>
 
 <div class = "post">
-	<h1 class = "post_title"><%= @post.title %></h1>
+	<h1 class = "post_title"><%= raw @post.title %></h1>
 
 	<div class = "post_body show">
 		<%= raw @post.body %>

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -11,7 +11,6 @@ require 'database_cleaner'
 require 'test_after_commit'
 require 'coffee_script'
 require 'sass'
-#Capybara.app = Proclaim::Engine
 
 Rails.backtrace_cleaner.remove_silencers!
 
@@ -24,6 +23,12 @@ Dir["#{File.dirname(__FILE__)}/support/**/*.rb"].each { |f| require f }
 #class ActionController::TestCase
 #	include Proclaim::Engine.routes.url_helpers
 #end
+
+# Selenium isn't working with Firefox 35 (01/16/14). Use Chrome instead, for
+# now. Too bad, really... I hate Chrome.
+Capybara.register_driver :selenium do |app|
+	Capybara::Selenium::Driver.new(app, :browser => :chrome)
+end
 
 class ActionDispatch::IntegrationTest
 	# Make the Capybara DSL available in all integration tests


### PR DESCRIPTION
This MR resolves #22 by ensuring HTML entities don't show up in the post titles.

It also moves the Capybara tests to using Chrome instead of Firefox due to Selenium not working with the most recent Firefox release (35).