### PR TITLE
Incorporate callbacks to notify main application of new records.

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,3 +1,5 @@
+  - Added callbacks as a way for main app to be notified of new posts,
+    comments, or subscriptions. Configured in initializer.
   - Fixed bug where email field didn't hide after successful comment
   - Added ability to administer subscriptions
   - Removed the use of calc from mailer layout

--- a/app/models/proclaim/comment.rb
+++ b/app/models/proclaim/comment.rb
@@ -17,6 +17,7 @@ module Proclaim
 		belongs_to :post, inverse_of: :comments
 		after_initialize :maintainPost
 		after_create :notifyPostSubscribers
+		after_create { Proclaim.notify_new_comment(self) }
 
 		validates_presence_of :body, :author, :post
 

--- a/app/models/proclaim/post.rb
+++ b/app/models/proclaim/post.rb
@@ -20,6 +20,8 @@ module Proclaim
 		has_many :images, inverse_of: :post, dependent: :destroy
 		accepts_nested_attributes_for :images, allow_destroy: true
 
+		after_create { Proclaim.notify_new_post(self) }
+
 		include AASM
 
 		aasm column: :state, no_direct_assignment: true do

--- a/app/models/proclaim/subscription.rb
+++ b/app/models/proclaim/subscription.rb
@@ -15,6 +15,7 @@ module Proclaim
 		belongs_to :post, inverse_of: :subscriptions
 
 		after_create :deliver_welcome_email
+		after_create { Proclaim.notify_new_subscription(self) }
 
 		# RFC-compliant email addresses are way nasty to match with regex, so why
 		# try? We'll be sending them an email anyway-- if they don't get it, they

--- a/lib/proclaim.rb
+++ b/lib/proclaim.rb
@@ -38,7 +38,70 @@ module Proclaim
 	mattr_accessor :secret_key
 	@@secret_key = nil
 
+	# Callbacks (must be Procs)
+	mattr_accessor :new_post_callbacks
+	@@new_post_callbacks = Array.new
+	private_class_method :new_post_callbacks, :new_post_callbacks=
+
+	mattr_accessor :new_comment_callbacks
+	@@new_comment_callbacks = Array.new
+	private_class_method :new_comment_callbacks, :new_comment_callbacks=
+
+	mattr_accessor :new_subscription_callbacks
+	@@new_subscription_callbacks = Array.new
+	private_class_method :new_subscription_callbacks,
+	                     :new_subscription_callbacks=
+
+	# Default way to setup Proclaim from initializer
 	def self.setup
 		yield self
+	end
+
+	def self.after_new_post(*callbacks, &block)
+		callbacks.each do |callback|
+			@@new_post_callbacks.unshift(callback)
+		end
+
+		if block_given?
+			@@new_post_callbacks.unshift(block)
+		end
+	end
+
+	def self.after_new_comment(*callbacks, &block)
+		callbacks.each do |callback|
+			@@new_comment_callbacks.unshift(callback)
+		end
+
+		if block_given?
+			@@new_comment_callbacks.unshift(block)
+		end
+	end
+
+	def self.after_new_subscription(*callbacks, &block)
+		callbacks.each do |callback|
+			@@new_subscription_callbacks.unshift(callback)
+		end
+
+		if block_given?
+			@@new_subscription_callbacks.unshift(block)
+		end
+	end
+
+	def self.notify_new_post(post)
+		@@new_post_callbacks.each do |callback|
+			callback.call(post)
+		end
+	end
+
+	def self.notify_new_comment(comment)
+		@@new_comment_callbacks.each do |callback|
+			callback.call(comment)
+		end
+	end
+
+	def self.notify_new_subscription(subscription)
+		@@new_subscription_callbacks.each do |callback|
+			callback.call(subscription)
+		end
 	end
 end


### PR DESCRIPTION
This PR resolves #38 by implementing callbacks as a way for the main application to be notified when new posts, comments, or subscriptions are made.