### PR TITLE
Add comment count to Post index.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,4 +1,8 @@
 language: ruby
+branches:
+  only:
+    - master
+    - develop
 script: bundle exec rake test
 rvm:
 - 1.9.3

--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,3 +1,5 @@
+  - Add comment count to Post index
+
 v 0.5.4
   - Integrate with Travis CI, Sauce Labs, and Code Climate
 

--- a/app/views/proclaim/posts/index.html.erb
+++ b/app/views/proclaim/posts/index.html.erb
@@ -33,7 +33,12 @@
 						<% end %>
 					</div>
 					<%= post.author.send(Proclaim.author_name_method) %><br />
-					<%= timeago_tag post.published_at, format: "%B %d, %Y" %>
+					<%= timeago_tag post.published_at, format: "%B %d, %Y" %><br />
+					<% if post.comments.empty? %>
+						No comments
+					<% else %>
+						<%= pluralize post.comments.count, "comment" %>
+					<% end %>
 				</div>
 			<% end %>
 			</td>

--- a/test/integration/without_javascript/post_test.rb
+++ b/test/integration/without_javascript/post_test.rb
@@ -145,6 +145,39 @@ class PostTest < ActionDispatch::IntegrationTest
 		       "Post 3 draft should be shown before post 1 draft!"
 	end
 
+	test "index should not show comment count for drafts" do
+		user = FactoryGirl.create(:user)
+		sign_in user
+
+		comment = FactoryGirl.create(:comment)
+
+		visit proclaim.posts_path
+
+		assert page.has_no_text? "1 comment"
+	end
+
+	test "index should show comment count for published post" do
+		user = FactoryGirl.create(:user)
+		sign_in user
+
+		# Verify no comments
+		post = FactoryGirl.create(:published_post)
+		visit proclaim.posts_path
+		assert page.has_text?("No comments"),
+		       "Comment count should indicate no comments"
+
+		# Verify that single comment count shows up.
+		comment = FactoryGirl.create(:published_comment, post: post)
+		visit proclaim.posts_path
+		assert page.has_text?("1 comment"), "Comment count should be shown"
+
+		# Also verify that the comment count is properly pluralized.
+		comment = FactoryGirl.create(:published_comment, post: comment.post)
+		visit proclaim.posts_path
+		assert page.has_text?("2 comments"),
+		       "Comment count should be shown and pluralized"
+	end
+
 	test "show should include author name" do
 		post = FactoryGirl.create(:published_post)
 


### PR DESCRIPTION
This PR resolves #56 by adding a comment count to the Post index page for each published post.